### PR TITLE
Fix backtick escaping in admin page script

### DIFF
--- a/web-config-manager-cloudflare.js
+++ b/web-config-manager-cloudflare.js
@@ -1185,8 +1185,8 @@ filterStatus.textContent = '正在筛选 ' + ipList.length + ' 个IP...';
                 });
                 const result = await response.json();
                 if (result.success) {
-                    filterStatus.textContent = `筛选完成：${result.validIps} 个有效IP，${result.addedIps} 个已添加`;
-                    showMessage(`IP筛选完成！有效IP: ${result.validIps}个，已添加: ${result.addedIps}个`, 'success');
+                    filterStatus.textContent = \`筛选完成：${result.validIps} 个有效IP，${result.addedIps} 个已添加\`;
+                    showMessage(\`IP筛选完成！有效IP: ${result.validIps}个，已添加: ${result.addedIps}个\`, 'success');
                     manualIpsTextarea.value = '';
                 } else {
                     filterStatus.textContent = '筛选失败';


### PR DESCRIPTION
## Summary
- escape backticks inside the admin page HTML template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686efa2a15748333b8e1fa25ea79a0d3