### PR TITLE
Fix env variable names in docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -104,8 +104,8 @@
 
    | 变量名 | 值 | 说明 |
    |--------|----|----|
-   | `CF_API_TOKEN` | 您的 API Token | 第三步获取的 Token |
-   | `CF_ZONE_ID` | 您的 Zone ID | 第三步获取的 Zone ID |
+   | `CLOUDFLARE_API_TOKEN` | 您的 API Token | 第三步获取的 Token |
+   | `CLOUDFLARE_ZONE_ID` | 您的 Zone ID | 第三步获取的 Zone ID |
    | `JWT_SECRET` | 随机字符串 | 用于 JWT 签名，建议32位随机字符 |
    | `ADMIN_PASSWORD` | 您的管理员密码 | 登录系统用的密码 |
 
@@ -220,11 +220,11 @@
 
 ### 常见错误及解决方案
 
-1. **"CF_API_TOKEN环境变量未设置"**
+1. **"CLOUDFLARE_API_TOKEN环境变量未设置"**
    - 检查环境变量是否正确添加
    - 确认变量名拼写正确
 
-2. **"CF_ZONE_ID格式不正确"**
+2. **"CLOUDFLARE_ZONE_ID格式不正确"**
    - 确认 Zone ID 是32位十六进制字符串
    - 检查是否有多余的空格
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ wrangler deploy
 
 | 变量名 | 说明 | 示例值 |
 |--------|------|--------|
-| `CF_API_TOKEN` | Cloudflare API 令牌 | `your_api_token_here` |
-| `CF_ZONE_ID` | Cloudflare Zone ID | `32位十六进制字符串` |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API 令牌 | `your_api_token_here` |
+| `CLOUDFLARE_ZONE_ID` | Cloudflare Zone ID | `32位十六进制字符串` |
 | `JWT_SECRET` | JWT 签名密钥 | `your_jwt_secret_here` |
 | `ADMIN_PASSWORD` | 管理员密码 | `your_admin_password` |
 
@@ -174,8 +174,8 @@ wrangler deploy
    - 系统会自动使用备用 IP 列表
 
 2. **DNS 更新失败**：
-   - 检查 CF_API_TOKEN 权限
-   - 确认 CF_ZONE_ID 正确
+   - 检查 CLOUDFLARE_API_TOKEN 权限
+   - 确认 CLOUDFLARE_ZONE_ID 正确
    - 检查域名是否在 Cloudflare 管理
 
 3. **通知发送失败**：


### PR DESCRIPTION
## Summary
- use `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` consistently in docs

## Testing
- `node -e "require('./web-config-manager-cloudflare.js');"`

------
https://chatgpt.com/codex/tasks/task_b_686efd54535483339de368b8c876eb28