### PR TITLE
Add types to env variable tables

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -102,12 +102,12 @@
 
 2. **必需的环境变量**
 
-   | 变量名 | 值 | 说明 |
-   |--------|----|----|
-   | `CLOUDFLARE_API_TOKEN` | 您的 API Token | 第三步获取的 Token |
-   | `CLOUDFLARE_ZONE_ID` | 您的 Zone ID | 第三步获取的 Zone ID |
-   | `JWT_SECRET` | 随机字符串 | 用于 JWT 签名，建议32位随机字符 |
-   | `ADMIN_PASSWORD` | 您的管理员密码 | 登录系统用的密码 |
+    | 变量名 | 类型 | 值 | 说明 |
+    |--------|------|----|----|
+    | `CLOUDFLARE_API_TOKEN` | 密钥 | 您的 API Token | 第三步获取的 Token |
+    | `CLOUDFLARE_ZONE_ID` | 文本 | 您的 Zone ID | 第三步获取的 Zone ID |
+    | `JWT_SECRET` | 密钥 | 随机字符串 | 用于 JWT 签名，建议32位随机字符 |
+    | `ADMIN_PASSWORD` | 密钥 | 您的管理员密码 | 登录系统用的密码 |
 
 3. **生成 JWT_SECRET**
    - 可以使用在线工具生成：[https://www.random.org/strings/](https://www.random.org/strings/)

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ wrangler deploy
 
 ### 必需环境变量
 
-| 变量名 | 说明 | 示例值 |
-|--------|------|--------|
-| `CLOUDFLARE_API_TOKEN` | Cloudflare API 令牌 | `your_api_token_here` |
-| `CLOUDFLARE_ZONE_ID` | Cloudflare Zone ID | `32位十六进制字符串` |
-| `JWT_SECRET` | JWT 签名密钥 | `your_jwt_secret_here` |
-| `ADMIN_PASSWORD` | 管理员密码 | `your_admin_password` |
+| 变量名 | 类型 | 说明 | 示例值 |
+|--------|------|------|--------|
+| `CLOUDFLARE_API_TOKEN` | 密钥 | Cloudflare API 令牌 | `your_api_token_here` |
+| `CLOUDFLARE_ZONE_ID` | 文本 | Cloudflare Zone ID | `32位十六进制字符串` |
+| `JWT_SECRET` | 密钥 | JWT 签名密钥 | `your_jwt_secret_here` |
+| `ADMIN_PASSWORD` | 密钥 | 管理员密码 | `your_admin_password` |
 
 ### 获取 Cloudflare API 信息
 


### PR DESCRIPTION
## Summary
- document variable types for required environment variables in `README.md`
- include variable types in deployment guide

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_686eff8a05e08333be018983e743c3a9