### PR TITLE
Add debug error responses

### DIFF
--- a/web-config-manager-cloudflare.js
+++ b/web-config-manager-cloudflare.js
@@ -938,12 +938,21 @@ async function handleRequest(request) {
       stack: error.stack,
       path, method, client_ip: clientIP
     }, requestId);
-    
-    return new Response(JSON.stringify({
+
+    const config = await getConfig();
+    const errorResponse = {
       success: false,
-      error: '服务器内部错误',
+      error: config.LOG_LEVEL === 'debug'
+        ? `服务器内部错误: ${error.message}`
+        : '服务器内部错误',
       requestId
-    }), {
+    };
+
+    if (config.LOG_LEVEL === 'debug') {
+      errorResponse.stack = error.stack;
+    }
+
+    return new Response(JSON.stringify(errorResponse), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
     });


### PR DESCRIPTION
## Summary
- provide more detailed error info when `LOG_LEVEL` is `debug`

## Testing
- `node -c web-config-manager-cloudflare.js`

------
https://chatgpt.com/codex/tasks/task_b_686f317132708333a979f992f7edc9eb