### PR TITLE
Fix escape in admin page template

### DIFF
--- a/web-config-manager-cloudflare.js
+++ b/web-config-manager-cloudflare.js
@@ -1225,8 +1225,8 @@ filterStatus.textContent = '正在筛选 ' + ipList.length + ' 个IP...';
                 });
                 const result = await response.json();
                 if (result.success) {
-                    filterStatus.textContent = \`筛选完成：${result.validIps} 个有效IP，${result.addedIps} 个已添加\`;
-                    showMessage(\`IP筛选完成！有效IP: ${result.validIps}个，已添加: ${result.addedIps}个\`, 'success');
+                    filterStatus.textContent = \`筛选完成：\${result.validIps} 个有效IP，\${result.addedIps} 个已添加\`;
+                    showMessage(\`IP筛选完成！有效IP: \${result.validIps}个，已添加: \${result.addedIps}个\`, 'success');
                     manualIpsTextarea.value = '';
                 } else {
                     filterStatus.textContent = '筛选失败';


### PR DESCRIPTION
## Summary
- fix reference error when generating admin page by escaping `${...}` in template

## Testing
- `node --check web-config-manager-cloudflare.js`


------
https://chatgpt.com/codex/tasks/task_b_686fcdaab4ac8333be9bd50e0c8b328a